### PR TITLE
Tests, CI, MoC investigation, linting, and type hints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,21 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install ruff
+        run: pip install ruff==0.16.4
+
+      - name: Run ruff
+        run: ruff check .

--- a/README.md
+++ b/README.md
@@ -103,11 +103,26 @@ Automated tests live in `tests/` and run via `pytest`, configured by `pytest.ini
 pytest
 ```
 
-Any bug fix or new solver logic should keep existing tests passing and add new tests alongside it. Note that test coverage today only spans the isentropic, oblique shock, and Taylor-Maccoll solvers — most of `src/` (the MoC solver, streamline integrator, surface pressure solver, etc.) has no automated tests yet.
+Any bug fix or new solver logic should keep existing tests passing and add new tests alongside it. Test coverage spans the isentropic, oblique shock, Taylor-Maccoll, and MoC point solvers, plus `point.py`, `process_LE_points.py`, `metric_derivative_solver.py`, and `velocity_altitude_map.py`. The streamline integrator and surface pressure solver still have no automated tests.
+
+A GitHub Actions workflow (`.github/workflows/tests.yml`) runs the full suite on every push and pull request against `main`, on Python 3.11 and 3.12.
 
 ---
 
-### 6. Add and Commit Changes
+### 6. Lint Your Changes
+
+This repo uses [ruff](https://docs.astral.sh/ruff/) for linting (unused imports/variables, import ordering, line length). Install it via the dev requirements file and run it from the repo root:
+
+```bash
+pip install -r requirements-dev.txt
+ruff check .
+```
+
+`ruff check .` also runs in CI on every push and pull request.
+
+---
+
+### 7. Add and Commit Changes
 
 After making and testing your changes:
 
@@ -125,7 +140,7 @@ After making and testing your changes:
 
 ---
 
-### 7. Push Your Branch and Open a Pull Request
+### 8. Push Your Branch and Open a Pull Request
 
 ```bash
 # Push your branch to GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes (unused imports/variables, undefined names, etc.)
+    "I",   # isort (import ordering)
+]
+ignore = [
+    "E741",  # ambiguous variable names (l, I, O) -- common in physics code (e.g. l for length)
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+ruff==0.16.4

--- a/src/MachCone_Vertex_Finder.py
+++ b/src/MachCone_Vertex_Finder.py
@@ -10,8 +10,10 @@ with this repo, so this script cannot be run end-to-end yet.
 ==================================================
 '''
 
-import numpy as np
 import math
+
+import numpy as np
+
 
 def read_nmb_file(file_ID):
     """
@@ -89,7 +91,7 @@ def mach_vertex(chords, ref_length):
     z_e = 0
 
     mach_vertex_chords = np.array([x_e, y_e, z_e]) * ref_length
-    
+
     return{
         "mach_vertex_chords": mach_vertex_chords
     }

--- a/src/axi-sym_MoC_solver.py
+++ b/src/axi-sym_MoC_solver.py
@@ -41,6 +41,15 @@ class MoC_Skeleton:
         wall point via solve_wall_point(). Stops early (returning the
         partial mesh) if either solve step fails to converge.
 
+        Note: solve_wall_point() models the body as a parabola valid only
+        within wall_params["x1"] to wall_params["x2"]. If i_max/delta_s are
+        large enough that the mesh marches past x2 before reaching i_max
+        rows, solve_wall_point() will fail once it tries to intersect a
+        characteristic with the wall beyond that domain (see its docstring)
+        -- this is a modeling-domain limit, not necessarily a bug. If you
+        hit this, check whether wall_params covers the z-extent you
+        actually need before assuming the math is wrong.
+
         Parameters
         ----------
         log_file : str

--- a/src/axi-sym_MoC_solver.py
+++ b/src/axi-sym_MoC_solver.py
@@ -1,8 +1,11 @@
 import os
-from point import Point
-from moc_solver_pc import AxisymMoC
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+
+from moc_solver_pc import AxisymMoC
+from point import Point
+
 
 class MoC_Skeleton:
     '''Builds a full axisymmetric MoC characteristic mesh, marching a grid of
@@ -91,7 +94,7 @@ class MoC_Skeleton:
                 PA = moc_mesh[i - 1][j]
                 PB = moc_mesh[i][j - 1]
                 PC = self.moc_solver.solve_internal_point(PA, PB)
-    
+
                 if PC is None:
                     return moc_mesh
                 moc_mesh[i][j] = PC

--- a/src/conical_flow_analyzer.py
+++ b/src/conical_flow_analyzer.py
@@ -1,9 +1,11 @@
+import pandas as pd
+
 from oblique_shock_solver import ObliqueShockSolver
 from taylor_maccoll_solver import TaylorMaccollSolver
 
 
 class ConicalFlowAnalyzer:
-    def __init__(self, M1, gamma):
+    def __init__(self, M1: float, gamma: float) -> None:
         """
         Initializes the ConicalFlowAnalyzer with Mach number and specific heat ratio.
 
@@ -16,7 +18,7 @@ class ConicalFlowAnalyzer:
         self.os_solver = ObliqueShockSolver(gamma=gamma)
         self.tm_solver = TaylorMaccollSolver(gamma=gamma)
 
-    def solve_taylor_maccoll(self, theta_s):
+    def solve_taylor_maccoll(self, theta_s: float) -> tuple[float, float, float]:
         """
         Solves for the cone angle and normalized velocity components
         given a shock angle using the Taylor-Maccoll and Oblique Shock Solvers.
@@ -44,7 +46,7 @@ class ConicalFlowAnalyzer:
 
         return theta_c, V_r, V_theta
 
-    def tabulate_tm_shock_to_cone(self, theta_s):
+    def tabulate_tm_shock_to_cone(self, theta_s: float) -> pd.DataFrame:
         """
         Solves from the shock angle to the cone angle using Taylor-Maccoll equations
         and generates a table of results.

--- a/src/conical_flow_analyzer.py
+++ b/src/conical_flow_analyzer.py
@@ -1,8 +1,6 @@
-import numpy as np
-import os
-import pandas as pd
 from oblique_shock_solver import ObliqueShockSolver
 from taylor_maccoll_solver import TaylorMaccollSolver
+
 
 class ConicalFlowAnalyzer:
     def __init__(self, M1, gamma):
@@ -20,7 +18,7 @@ class ConicalFlowAnalyzer:
 
     def solve_taylor_maccoll(self, theta_s):
         """
-        Solves for the cone angle and normalized velocity components 
+        Solves for the cone angle and normalized velocity components
         given a shock angle using the Taylor-Maccoll and Oblique Shock Solvers.
 
         Parameters:
@@ -45,7 +43,7 @@ class ConicalFlowAnalyzer:
         theta_c, V_r, V_theta = self.tm_solver.solve(theta_w, V_r, V_theta)
 
         return theta_c, V_r, V_theta
-    
+
     def tabulate_tm_shock_to_cone(self, theta_s):
         """
         Solves from the shock angle to the cone angle using Taylor-Maccoll equations

--- a/src/isentropic_relations_solver.py
+++ b/src/isentropic_relations_solver.py
@@ -1,6 +1,6 @@
 class IsentropicRelationsSolver:
 
-    def __init__(self, gamma=1.4):
+    def __init__(self, gamma: float = 1.4) -> None:
         '''
         Initializes the isentropic shock solver with a specific heat ratio.
 
@@ -11,7 +11,7 @@ class IsentropicRelationsSolver:
         '''
         self.gamma = gamma
 
-    def isentropic_relations(self, Mach):
+    def isentropic_relations(self, Mach: float) -> dict[str, float]:
         """
         Calculates isentropic relations for a given Mach number and the
         solver's specific heat ratio.

--- a/src/lower_surface_pressure_solver.py
+++ b/src/lower_surface_pressure_solver.py
@@ -1,9 +1,12 @@
 import os
+
 import numpy as np
-from stl import mesh
 import pyvista as pv
 from scipy.interpolate import interp1d
-from velocity_altitude_map import calculate_pressure, calculate_dynamic_pressure
+from stl import mesh
+
+from velocity_altitude_map import calculate_dynamic_pressure, calculate_pressure
+
 
 class SurfaceMeshAnalyzer:
     def __init__(self, file_path):
@@ -103,8 +106,11 @@ class SurfaceMeshAnalyzer:
 
         self.cell_mach = mach_interp(self.angles)
         cell_P_P0 = P_P0_interp(self.angles)
-        cell_T_T0 = T_T0_interp(self.angles)
-        cell_rho_rho0 = rho_rho0_interp(self.angles)
+        # Stored on self (matching self.cell_mach above) rather than kept
+        # local: export_to_vtk() already has commented-out lines expecting
+        # self.cell_T_T0 / self.cell_rho_rho0 to exist.
+        self.cell_T_T0 = T_T0_interp(self.angles)
+        self.cell_rho_rho0 = rho_rho0_interp(self.angles)
 
         # Look into stag_properties to get stagnation pressure (P0)
         P0 = stag_properties["P0"]
@@ -115,7 +121,7 @@ class SurfaceMeshAnalyzer:
         self.cell_Cl_exact = self.cell_Cp_exact * np.sin(np.radians(90) - self.angles)
         self.cell_Cd_exact = self.cell_Cp_exact * np.cos(np.radians(90) - self.angles)
 
-    
+
     def calculate_newtonian_pressure_coefficients_cell(self):
         """
         Use modified newtonian theory to calculate the pressure distribution given the angle of a unit normal
@@ -125,7 +131,7 @@ class SurfaceMeshAnalyzer:
         Returns
             None.
         """
-        
+
         self.cell_Cp_newtonian = 2 * np.sin(self.angles)**2
         self.cell_Cd_newtonian = 2 * np.sin(self.angles)**3
         self.cell_Cl_newtonian =  np.cos(self.angles) * 2 * np.sin(self.angles)**2
@@ -142,7 +148,7 @@ class SurfaceMeshAnalyzer:
 
         Returns
         -------
-            - Cp_vehicle: Singular Cp value across entire vehicle. 
+            - Cp_vehicle: Singular Cp value across entire vehicle.
         """
         Cp_vehicle = np.sum(Cp_input*self.cell_areas)/np.sum(self.cell_areas)
 
@@ -158,7 +164,7 @@ class SurfaceMeshAnalyzer:
 
         # Convert STL to PyVista Mesh
         points = self.mesh.vectors.reshape(-1, 3)  # Extract unique points
-        faces = np.hstack([np.full((len(self.mesh.vectors), 1), 3), 
+        faces = np.hstack([np.full((len(self.mesh.vectors), 1), 3),
                            np.arange(len(points)).reshape(-1, 3)]).astype(np.int64)
 
         pv_mesh = pv.PolyData(points, faces)
@@ -203,7 +209,7 @@ if __name__ == "__main__":
             print(f'Cell {i}: Area = {analyzer.cell_areas[i]:.6f}, '
                   f'Normal Vector = {analyzer.normal_vectors[i]}, '
                   f'Angle (deg) = {np.degrees(analyzer.angles[i]):.2f}')
-    
+
     from taylor_maccoll_solver import TaylorMaccollSolver
     tm_solver = TaylorMaccollSolver(gamma=1.2)
 
@@ -212,7 +218,7 @@ if __name__ == "__main__":
     theta_c = np.radians(18.1951829)
     Mc = 6.41062720
     V_0, Vr0, dVr0 = tm_solver.calculate_velocity_components(Mc, theta_c, theta_c)
-    
+
     results_df = tm_solver.tabulate_from_shock_to_cone(theta_s, theta_c, Vr0, dVr0)
 
     altitude = 30000 # meters

--- a/src/metric_derivative_solver.py
+++ b/src/metric_derivative_solver.py
@@ -18,6 +18,7 @@ import numpy as np
 from scipy.integrate import solve_ivp
 from scipy.interpolate import RegularGridInterpolator
 
+
 def compute_metric_values(eta_grid, xi_grid, x_vals, y_vals, u_field, v_field):
     '''
     Computes the grid metric derivatives (eta_x, eta_y, xi_x, xi_y) that
@@ -185,7 +186,9 @@ if __name__ == "__main__":
                                              (eta_grid, xi_grid), metric_values, method='manual')
 
     print("Scipy Interpolation Result:")
-    print(f"  eta1 = {result_scipy[0]:.8f}, xi1 = {result_scipy[1]:.8f}, x1 = {result_scipy[2]:.8f}, y1 = {result_scipy[3]:.8f}")
+    print(f"  eta1 = {result_scipy[0]:.8f}, xi1 = {result_scipy[1]:.8f}, "
+          f"x1 = {result_scipy[2]:.8f}, y1 = {result_scipy[3]:.8f}")
 
     print("\n Manual Interpolation Result:")
-    print(f"  eta1 = {result_manual[0]:.8f}, xi1 = {result_manual[1]:.8f}, x1 = {result_manual[2]:.8f}, y1 = {result_manual[3]:.8f}")
+    print(f"  eta1 = {result_manual[0]:.8f}, xi1 = {result_manual[1]:.8f}, "
+          f"x1 = {result_manual[2]:.8f}, y1 = {result_manual[3]:.8f}")

--- a/src/moc_solver_pc.py
+++ b/src/moc_solver_pc.py
@@ -16,8 +16,10 @@ Nomenclature:
 ==================================================
 '''
 
-from point import Point
 import numpy as np
+
+from point import Point
+
 
 class AxisymMoC:
     '''Predictor-corrector solver for one step of the axisymmetric MoC mesh:
@@ -124,7 +126,7 @@ class AxisymMoC:
             r_c_new = drdz_a * (z_c_new - z_a) + r_a
 
             C1 = 0.5 * ((1 / (np.tan(mu_c_prime) * q_c_prime)) + (1 / (np.tan(mu_a) * q_a)))
-            
+
             C2_a = np.sin(mu_a) * np.sin(theta_a) / (r_a * np.cos(theta_a + mu_a))
             C2_b = np.sin(mu_c_prime) * np.sin(theta_c_prime) / (r_c_prime * np.cos(theta_c_prime + mu_c_prime))
             C2 = 0.5 * (C2_a + C2_b) * (z_c_new - z_a)
@@ -140,15 +142,16 @@ class AxisymMoC:
 
             # Equation 2.27
             M_c_new = np.sqrt(2 / ((self.gamma - 1) * (((self.q_max / q_c_new) ** 2) - 1)))
-            
+
             # Equation 2.26
             mu_c_new = np.arcsin(1 / M_c_new)
 
             if abs(q_c_new - q_c_prime) / q_c_prime < tol:
-                
+
                 break
 
-            z_c_prime, r_c_prime, theta_c_prime, M_c_prime, q_c_prime = z_c_new, r_c_new, theta_c_new, M_c_new, q_c_new
+            z_c_prime, r_c_prime, theta_c_prime, M_c_prime, mu_c_prime, q_c_prime = \
+                z_c_new, r_c_new, theta_c_new, M_c_new, mu_c_new, q_c_new
 
         return Point(z_c_prime, r_c_prime, theta_c_prime, M_c_prime, q_c_prime)
 
@@ -196,7 +199,7 @@ class AxisymMoC:
         a = drdz_b
         b = (r2 - r1) / ((z2 - z1) ** 2)
         c = b * (z1 * z1) + (a * z_b) - r_b +r1
-        
+
         det = ((-2 * b * z1 - a) ** 2) - (4 * b * c)
         if det < 0:
             # The straight-line predictor from PB has no real intersection
@@ -271,10 +274,11 @@ class AxisymMoC:
             mu_c_new = np.arcsin(1 / M_c_new)
 
             if abs(q_c_new - q_c_prime) / q_c_prime < tol:
-            
+
                 break
 
-            z_c_prime, r_c_prime, theta_c_prime, M_c_prime, mu_c_prime, q_c_prime = z_c_new, r_c_new, theta_c_new, M_c_new, mu_c_new, q_c_new
+            z_c_prime, r_c_prime, theta_c_prime, M_c_prime, mu_c_prime, q_c_prime = \
+                z_c_new, r_c_new, theta_c_new, M_c_new, mu_c_new, q_c_new
 
         return Point(z_c_prime, r_c_prime, theta_c_prime, M_c_prime, q_c_prime)
 

--- a/src/moc_solver_pc.py
+++ b/src/moc_solver_pc.py
@@ -26,7 +26,7 @@ class AxisymMoC:
     given two known characteristic points, solves for the downstream point
     where their characteristics intersect (interior) or meet the body wall.'''
 
-    def __init__(self, q_max, gamma, wall_params):
+    def __init__(self, q_max: float, gamma: float, wall_params: dict[str, float]) -> None:
         '''
         Parameters
         ----------
@@ -42,7 +42,9 @@ class AxisymMoC:
         self.q_max = q_max
         self.wall_params = wall_params
 
-    def solve_internal_point(self, PA, PB, max_iters=15, tol=1e-7):
+    def solve_internal_point(
+        self, PA: Point, PB: Point, max_iters: int = 15, tol: float = 1e-7
+    ) -> Point:
         '''
         Solves for a new characteristic mesh point C at the intersection of
         the C+ characteristic through PA and the C- characteristic through PB,
@@ -155,7 +157,9 @@ class AxisymMoC:
 
         return Point(z_c_prime, r_c_prime, theta_c_prime, M_c_prime, q_c_prime)
 
-    def solve_wall_point(self, PB, max_iters=15, tol=1e-7):
+    def solve_wall_point(
+        self, PB: Point, max_iters: int = 15, tol: float = 1e-7
+    ) -> Point | None:
         '''
         Solves for a new characteristic mesh point C on the parabolic body
         wall, where the C- characteristic through PB meets the wall,

--- a/src/moc_solver_pc.py
+++ b/src/moc_solver_pc.py
@@ -199,7 +199,22 @@ class AxisymMoC:
         
         det = ((-2 * b * z1 - a) ** 2) - (4 * b * c)
         if det < 0:
-            print('neg')
+            # The straight-line predictor from PB has no real intersection
+            # with the parabolic wall. In practice this has been observed
+            # to happen once PB has marched past the wall's defined z-extent
+            # (z_b > x2): the parabola is only a model of the body within
+            # [x1, x2], and extrapolating it further can easily stop
+            # intersecting the characteristic line at all. It is not
+            # necessarily a bug in this solve -- if you hit this, check
+            # whether z_b below is beyond wall_params["x2"] before assuming
+            # the mesh math is wrong.
+            if z_b > z2 or z_b < z1:
+                print(f"solve_wall_point: no real intersection (det={det:.4g}); "
+                      f"z_b={z_b:.4f} is outside the wall's defined domain "
+                      f"[{z1:.4f}, {z2:.4f}]")
+            else:
+                print(f"solve_wall_point: no real intersection (det={det:.4g}) "
+                      f"at z_b={z_b:.4f}, within wall domain [{z1:.4f}, {z2:.4f}]")
             return None
         z_c_prime = (2 * b * z1 + a + np.sqrt(det)) / (2 * b)
 

--- a/src/oblique_shock_solver.py
+++ b/src/oblique_shock_solver.py
@@ -27,7 +27,7 @@ import numpy as np
 
 
 class ObliqueShockSolver:
-    def __init__(self, gamma=1.4):
+    def __init__(self, gamma: float = 1.4) -> None:
         '''
             Initializes the oblique shock solver with a specific heat ratio.
 
@@ -38,7 +38,7 @@ class ObliqueShockSolver:
         '''
         self.gamma = gamma
 
-    def calculate_flow_deflection_angle(self, M1, theta_s):
+    def calculate_flow_deflection_angle(self, M1: float, theta_s: float) -> float:
         '''
             Calculates the flow deflection angle (delta).
 
@@ -58,7 +58,7 @@ class ObliqueShockSolver:
         delta = np.arctan(1 / cot_delta)
         return delta
 
-    def calculate_post_shock_conditions(self, M1, theta_s):
+    def calculate_post_shock_conditions(self, M1: float, theta_s: float) -> dict[str, float]:
         """
         Calculates the post-shock conditions, including the downstream Mach number (M2),
         flow deflection angle (delta), and thermodynamic property ratios.

--- a/src/oblique_shock_solver.py
+++ b/src/oblique_shock_solver.py
@@ -25,6 +25,7 @@ Nomenclature:
 
 import numpy as np
 
+
 class ObliqueShockSolver:
     def __init__(self, gamma=1.4):
         '''
@@ -59,7 +60,7 @@ class ObliqueShockSolver:
 
     def calculate_post_shock_conditions(self, M1, theta_s):
         """
-        Calculates the post-shock conditions, including the downstream Mach number (M2), 
+        Calculates the post-shock conditions, including the downstream Mach number (M2),
         flow deflection angle (delta), and thermodynamic property ratios.
 
         Parameters

--- a/src/point.py
+++ b/src/point.py
@@ -6,7 +6,7 @@ class Point:
     throughout the axisymmetric MoC solver (moc_solver_pc.py,
     axi-sym_MoC_solver.py).'''
 
-    def __init__(self, x, r, theta, M, q):
+    def __init__(self, x: float, r: float, theta: float, M: float, q: float) -> None:
         '''
         Parameters
         ----------
@@ -28,7 +28,7 @@ class Point:
         self.mu = np.arcsin(1 / M)  # local Mach angle (radians)
         self.q = q
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f"Point(x={self.x:.2f}, r={self.r:.2f}, "
                 f"theta={np.degrees(self.theta):.2f}°, M={self.M:.3f}, "
                 f"mu={np.degrees(self.mu):.2f}°, q={self.q:.2f})")

--- a/src/point.py
+++ b/src/point.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class Point:
     '''Shared state object for a single characteristic mesh point, used
     throughout the axisymmetric MoC solver (moc_solver_pc.py,

--- a/src/process_LE_points.py
+++ b/src/process_LE_points.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+
 def extract_points_from_file(file_path):
     '''
     Extracts 3D points from a formatted text file and returns them as a pandas DataFrame.
@@ -26,7 +27,7 @@ def extract_points_from_file(file_path):
 
     # Extract the points, which are the next 'num_points' lines
     point_lines = lines[1:num_points + 1]
-    
+
     # Parse the points into a pandas DataFrame
     data = [list(map(float, line.split()[0:3])) for line in point_lines]
     df = pd.DataFrame(data, columns=['X', 'Y', 'Z'])

--- a/src/streamline_integrator.py
+++ b/src/streamline_integrator.py
@@ -1,9 +1,10 @@
 import os
-import random
+
 import numpy as np
-import pandas as pd
-from conical_flow_analyzer import ConicalFlowAnalyzer
+
 import process_LE_points
+from conical_flow_analyzer import ConicalFlowAnalyzer
+
 
 class StreamlineIntegrator:
     def __init__(self, gamma, M1, theta_s):
@@ -48,11 +49,11 @@ class StreamlineIntegrator:
         order = 0 # tracks # of points in a streamline
 
         # **Store the first point explicitly (the leading edge point)**
-        streamline_points.append([x * self.ref_length, 
-                                y * self.ref_length, 
+        streamline_points.append([x * self.ref_length,
+                                y * self.ref_length,
                                 z * self.ref_length, streamline_id, order])
         order += 1  # Increment order before stepping forward
-        
+
         alpha = np.arctan(abs(z / y))
 
         max_steps = 100_000  # safety bound: prevents an infinite loop if a
@@ -86,10 +87,10 @@ class StreamlineIntegrator:
             z = w * np.sin(alpha)
 
             # Store points with streamline ID and order
-            streamline_points.append([x * self.ref_length, 
-                                      y * self.ref_length, 
+            streamline_points.append([x * self.ref_length,
+                                      y * self.ref_length,
                                       z * self.ref_length, streamline_id, order])
-            
+
             order += 1
 
             if np.isclose(theta, self.theta_c, rtol=0.01):
@@ -105,7 +106,7 @@ class StreamlineIntegrator:
         """
         Generates the lower surface by tracing streamlines from the leading-edge (LE) points.
 
-        The function normalizes the LE points, traces each streamline, and prints the 
+        The function normalizes the LE points, traces each streamline, and prints the
         trajectory to the console.
 
         Parameters:
@@ -149,13 +150,13 @@ class StreamlineIntegrator:
             for streamline_id in set(point[3] for point in self.streamline_data):
                 # Filter out points that exceed ref_length
                 streamline = [p for p in self.streamline_data if p[3] == streamline_id]
-                
+
                 if not streamline or len(streamline) == 1:
                     continue
-                
+
                 # Write the number of points in the streamline
                 f.write(f"{len(streamline)}\n")
-                
+
                 # Write the coordinates with streamline_id and order
                 for x, y, z, s_id, order in streamline:
                     f.write(f"{x}\t{y}\t{z}\n")
@@ -164,7 +165,7 @@ class StreamlineIntegrator:
 
     def close_streamline_segments(self, filename):
         """
-        Closes the segments by adding additional segments connecting the first points 
+        Closes the segments by adding additional segments connecting the first points
         and last points of adjacent streamlines.
 
         Parameters:
@@ -194,17 +195,17 @@ class StreamlineIntegrator:
 
             # Connect first points of adjacent streamlines
             for i in range(len(first_points) - 1):
-                f.write(f"2\n")
+                f.write("2\n")
                 f.write(f"{first_points[i][0]}\t{first_points[i][1]}\t{first_points[i][2]}\n")
                 f.write(f"{first_points[i + 1][0]}\t{first_points[i + 1][1]}\t{first_points[i + 1][2]}\n")
 
             # Connect last points of adjacent streamlines
             for i in range(len(last_points) - 1):
-                f.write(f"2\n")
+                f.write("2\n")
                 f.write(f"{last_points[i][0]}\t{last_points[i][1]}\t{last_points[i][2]}\n")
                 f.write(f"{last_points[i + 1][0]}\t{last_points[i + 1][1]}\t{last_points[i + 1][2]}\n")
 
-        print(f"Closing segments appended to {filename}") 
+        print(f"Closing segments appended to {filename}")
 
 # Example Usage
 if __name__ == "__main__":

--- a/src/taylor_maccoll_solver.py
+++ b/src/taylor_maccoll_solver.py
@@ -30,7 +30,7 @@ from isentropic_relations_solver import IsentropicRelationsSolver
 
 
 class TaylorMaccollSolver:
-    def __init__(self, gamma=1.4, step_size=0.0001):
+    def __init__(self, gamma: float = 1.4, step_size: float = 0.0001) -> None:
         '''
         Initializes the Taylor-Maccoll solver with default parameters.
 
@@ -44,7 +44,9 @@ class TaylorMaccollSolver:
         self.gamma = gamma
         self.h = step_size
 
-    def calculate_velocity_components(self, M, theta, delta):
+    def calculate_velocity_components(
+        self, M: float, theta: float, delta: float
+    ) -> tuple[float, float, float]:
         '''
         Calculates and decomposes the normalized velocity magnitude (V') into its components.
 
@@ -79,7 +81,7 @@ class TaylorMaccollSolver:
         # Return the computed values
         return V_prime, V_r, V_theta
 
-    def calculate_Mach_from_components(self, V_r, V_theta):
+    def calculate_Mach_from_components(self, V_r: float, V_theta: float) -> float:
         '''
         Calculates the Mach number from the radial and tangential velocity components.
 
@@ -108,7 +110,7 @@ class TaylorMaccollSolver:
         # Return the computed Mach number
         return M
 
-    def taylor_maccoll_system(self, theta, Vr, dVr):
+    def taylor_maccoll_system(self, theta: float, Vr: float, dVr: float) -> np.ndarray:
         '''
         Defines the Taylor-Maccoll ODE system.
 
@@ -133,7 +135,7 @@ class TaylorMaccollSolver:
         ddVr = numerator / denominator
         return np.array([dVr, ddVr])
 
-    def rk4_step(self, theta, Vr, dVr):
+    def rk4_step(self, theta: float, Vr: float, dVr: float) -> tuple[float, float]:
         '''
         Performs a single RK4 integration step for Taylor-Maccoll equations.
 
@@ -186,7 +188,7 @@ class TaylorMaccollSolver:
 
         return Vr_next, dVr_next
 
-    def solve(self, theta0, Vr0, dVr0):
+    def solve(self, theta0: float, Vr0: float, dVr0: float) -> tuple[float, float, float]:
         '''
         Solves the Taylor-Maccoll equation and returns the final values.
 
@@ -216,7 +218,9 @@ class TaylorMaccollSolver:
         # Return final values
         return theta, Vr, dVr
 
-    def tabulate_from_shock_to_cone(self, theta_s, theta_c, Vr0, dVr0):
+    def tabulate_from_shock_to_cone(
+        self, theta_s: float, theta_c: float, Vr0: float, dVr0: float
+    ) -> pd.DataFrame:
         '''
         Solves the Taylor-Maccoll equation and returns a DataFrame with results.
 

--- a/src/taylor_maccoll_solver.py
+++ b/src/taylor_maccoll_solver.py
@@ -25,7 +25,9 @@ Nomenclature:
 
 import numpy as np
 import pandas as pd
+
 from isentropic_relations_solver import IsentropicRelationsSolver
+
 
 class TaylorMaccollSolver:
     def __init__(self, gamma=1.4, step_size=0.0001):
@@ -157,24 +159,24 @@ class TaylorMaccollSolver:
         # K2 and M2
         K2 = self.h * (dVr + 0.5 * M1)
         M2 = self.h * self.taylor_maccoll_system(
-            theta + 0.5 * self.h, 
-            Vr + 0.5 * K1, 
+            theta + 0.5 * self.h,
+            Vr + 0.5 * K1,
             dVr + 0.5 * M1
         )[1]
 
         # K3 and M3
         K3 = self.h * (dVr + 0.5 * M2)
         M3 = self.h * self.taylor_maccoll_system(
-            theta + 0.5 * self.h, 
-            Vr + 0.5 * K2, 
+            theta + 0.5 * self.h,
+            Vr + 0.5 * K2,
             dVr + 0.5 * M2
         )[1]
 
         # K4 and M4
         K4 = self.h * (dVr + M3)
         M4 = self.h * self.taylor_maccoll_system(
-            theta + self.h, 
-            Vr + K3, 
+            theta + self.h,
+            Vr + K3,
             dVr + M3
         )[1]
 
@@ -213,7 +215,7 @@ class TaylorMaccollSolver:
 
         # Return final values
         return theta, Vr, dVr
-    
+
     def tabulate_from_shock_to_cone(self, theta_s, theta_c, Vr0, dVr0):
         '''
         Solves the Taylor-Maccoll equation and returns a DataFrame with results.
@@ -265,7 +267,10 @@ class TaylorMaccollSolver:
             results.append([theta, M, Vr, dVr, p_ratio, t_ratio, rho_ratio])
 
         # Create and return DataFrame
-        results_df = pd.DataFrame(results, columns=["Theta (radians)", "Mach", "V_r", "V_theta", "P/P0", "T/T0", "rho/rho0"])
+        results_df = pd.DataFrame(
+            results,
+            columns=["Theta (radians)", "Mach", "V_r", "V_theta", "P/P0", "T/T0", "rho/rho0"],
+        )
         return results_df
 
 # Example usage
@@ -275,6 +280,6 @@ if __name__ == "__main__":
     theta_c = np.radians( 26.5909011)
     Mc = 3.57846955
     V_0, Vr0, dVr0 = solver.calculate_velocity_components(Mc, theta_c, theta_c)
-    
+
     results_df = solver.tabulate_from_shock_to_cone(theta_s, theta_c, Vr0, dVr0)
     print(results_df.head())

--- a/src/velocity_altitude_map.py
+++ b/src/velocity_altitude_map.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 
 def calculate_pressure(altitude):
     '''
@@ -113,8 +114,6 @@ def plot_altitude_vs_mach(gamma, dynamic_pressures):
         mach_numbers = []
         for altitude in altitudes:
             pressure = calculate_pressure(altitude)
-            temperature = calculate_temperature(altitude)
-            density = calculate_density(pressure, temperature)
             # Calculate Mach number for given dynamic pressure (q)
             mach = np.sqrt((2 * q) / (gamma * pressure))
             mach_numbers.append(mach)

--- a/tests/test_isen_solver.py
+++ b/tests/test_isen_solver.py
@@ -1,6 +1,8 @@
-import pytest
 import numpy as np
+import pytest
+
 from src.isentropic_relations_solver import IsentropicRelationsSolver
+
 
 # Fixture to initialize the solver instance
 @pytest.fixture
@@ -11,7 +13,7 @@ def test_isentropic_relation(solver):
     """
     Test the calculation of the isentropic relations solver.
     """
-    
+
     isentropic_relations_dict = solver.isentropic_relations(Mach=5)
 
     Mach = isentropic_relations_dict["Mach Number"]
@@ -19,7 +21,7 @@ def test_isentropic_relation(solver):
     Static_Pressure_Ratio = isentropic_relations_dict["Static Pressure Ratio (p/p0)"]
     Static_Temperature_Ratio = isentropic_relations_dict["Static Temperature Ratio (T/T0)"]
     Static_Density_Ratio  = isentropic_relations_dict["Static Density Ratio (rho/rho0)"]
-    
+
     # Expected value
     expected_Mach = 5
     expected_Specific_Heat_Ratio = 1.4
@@ -33,4 +35,4 @@ def test_isentropic_relation(solver):
     assert np.isclose(Static_Temperature_Ratio, expected_Static_Temperature_Ratio, atol=1e-3)
     assert np.isclose(Static_Density_Ratio, expected_Static_Density_Ratio, atol=1e-3)
 
-    
+

--- a/tests/test_metric_derivative_solver.py
+++ b/tests/test_metric_derivative_solver.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+from src.metric_derivative_solver import compute_metric_values, metric_derivative_solver
+
+
+def _build_simple_grid():
+    """
+    Small, mildly-warped grid with a smooth synthetic velocity field,
+    matching the shape/conventions used in this module's own __main__
+    example.
+    """
+    np.random.seed(0)
+    eta_grid = np.linspace(0, 1, 8)
+    xi_grid = np.linspace(0, 1, 8)
+
+    x_vals, y_vals = np.meshgrid(xi_grid, eta_grid, indexing='ij')
+    x_vals = x_vals + 0.05 * np.random.rand(*x_vals.shape)
+    y_vals = y_vals + 0.05 * np.random.rand(*y_vals.shape)
+
+    u_field = np.sin(np.pi * x_vals) * np.cos(np.pi * y_vals)
+    v_field = -np.cos(np.pi * x_vals) * np.sin(np.pi * y_vals)
+
+    return eta_grid, xi_grid, x_vals, y_vals, u_field, v_field
+
+
+def test_compute_metric_values_shape_and_finiteness():
+    eta_grid, xi_grid, x_vals, y_vals, u_field, v_field = _build_simple_grid()
+    metric_values = compute_metric_values(eta_grid, xi_grid, x_vals, y_vals, u_field, v_field)
+
+    # 6 stacked fields: [v, u, eta_x, eta_y, xi_x, xi_y]
+    assert metric_values.shape == (len(eta_grid), len(xi_grid), 6)
+    assert np.all(np.isfinite(metric_values))
+
+
+def test_manual_and_scipy_interpolation_agree():
+    """
+    Self-consistency check: the hand-written bilinear interpolator
+    ('manual') and scipy's RegularGridInterpolator ('scipy') are two
+    independent implementations of the same interpolation and should
+    agree closely for identical inputs. This does NOT verify the
+    underlying physics against Bowcutt's dissertation (that validation is
+    still pending) -- it only guards against the two code paths silently
+    diverging from each other.
+    """
+    eta_grid, xi_grid, x_vals, y_vals, u_field, v_field = _build_simple_grid()
+    metric_values = compute_metric_values(eta_grid, xi_grid, x_vals, y_vals, u_field, v_field)
+
+    eta0, xi0 = 0.35, 0.4
+    i0 = np.searchsorted(eta_grid, eta0)
+    j0 = np.searchsorted(xi_grid, xi0)
+    x0, y0 = x_vals[j0, i0], y_vals[j0, i0]
+    u0, v0 = u_field[j0, i0], v_field[j0, i0]
+
+    result_scipy = metric_derivative_solver(
+        v0, u0, x0, y0, eta0, xi0, (eta_grid, xi_grid), metric_values, method='scipy'
+    )
+    result_manual = metric_derivative_solver(
+        v0, u0, x0, y0, eta0, xi0, (eta_grid, xi_grid), metric_values, method='manual'
+    )
+
+    for scipy_val, manual_val, name in zip(result_scipy, result_manual, ["eta1", "xi1", "x1", "y1"]):
+        assert np.isclose(scipy_val, manual_val, atol=1e-6), (
+            f"{name} disagreement between manual and scipy interpolation: "
+            f"{manual_val} vs {scipy_val}"
+        )
+
+
+def test_metric_derivative_solver_rejects_unknown_method():
+    eta_grid, xi_grid, x_vals, y_vals, u_field, v_field = _build_simple_grid()
+    metric_values = compute_metric_values(eta_grid, xi_grid, x_vals, y_vals, u_field, v_field)
+
+    with pytest.raises(ValueError):
+        metric_derivative_solver(
+            0, 0, 0, 0, 0.5, 0.5, (eta_grid, xi_grid), metric_values, method='bogus'
+        )

--- a/tests/test_metric_derivative_solver.py
+++ b/tests/test_metric_derivative_solver.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from src.metric_derivative_solver import compute_metric_values, metric_derivative_solver
 
 

--- a/tests/test_moc_solver_pc.py
+++ b/tests/test_moc_solver_pc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from src.moc_solver_pc import AxisymMoC
 from src.point import Point
 
@@ -48,8 +49,8 @@ def test_solve_wall_point_succeeds_when_intersection_exists(solver):
     extrapolated parabola here, it just isn't guaranteed to in general
     (see the next test).
     """
-    PB = Point(x=10.084175290859454, r=2.3015659141074742, theta=-0.3524386403089323,
-               M=9.437775698916417, q=2057.118908975743)
+    PB = Point(x=10.083353806578721, r=2.3018799591411687, theta=-0.3524007055176659,
+               M=9.437497666282209, q=2057.1127917634576)
 
     PC = solver.solve_wall_point(PB)
 
@@ -70,8 +71,8 @@ def test_solve_wall_point_returns_none_past_wall_domain(solver, capsys):
     that the failure is now reported with a specific reason instead of a
     bare "neg".
     """
-    PB = Point(x=11.274183599427833, r=1.806742556073436, theta=-0.4059936956119819,
-               M=9.779187079764256, q=2064.278696921383)
+    PB = Point(x=11.274089564764987, r=1.806896382021175, theta=-0.4059541829010448,
+               M=9.778682440734498, q=2064.2686118427255)
 
     PC = solver.solve_wall_point(PB)
 

--- a/tests/test_moc_solver_pc.py
+++ b/tests/test_moc_solver_pc.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+from src.moc_solver_pc import AxisymMoC
+from src.point import Point
+
+# Wall/flow parameters matching axi-sym_MoC_solver.py's own __main__ example
+# (M_inf=7, gamma=1.2, at 30,000 m). q_max computed the same way MoC_Skeleton
+# computes it, so these fixture points are self-consistent with a real mesh.
+GAMMA = 1.2
+Q_MAX = 2169.5234831639873
+WALL_PARAMS = {"x1": 3.5010548, "x2": 9.39262, "r1": 3.5507, "r2": 2.5}
+
+
+@pytest.fixture
+def solver():
+    return AxisymMoC(q_max=Q_MAX, gamma=GAMMA, wall_params=WALL_PARAMS)
+
+
+def test_solve_internal_point_matches_known_mesh_point(solver):
+    """
+    Regression test: PA/PB/expected-PC below were captured from an actual
+    run of MoC_Skeleton.MoC_Mesher() with the parameters above (points
+    mesh[9][5], mesh[10][4], mesh[10][5]). This locks in current behavior
+    as a change-detector for solve_internal_point -- it is NOT an
+    independent verification against Bowcutt's dissertation, which is
+    still pending.
+    """
+    PA = Point(x=5.148697413726159, r=3.54749733765658, theta=-0.06749373622574202,
+               M=7.41593070819111, q=1995.660259749471)
+    PB = Point(x=5.111178875710549, r=3.5896159582877574, theta=-0.05229025710246242,
+               M=7.3195636557447825, q=1991.603615559419)
+
+    PC = solver.solve_internal_point(PA, PB)
+
+    assert np.isclose(PC.x, 5.278803348157691, rtol=1e-6)
+    assert np.isclose(PC.r, 3.556342326626543, rtol=1e-6)
+    assert np.isclose(PC.theta, -0.06734593291497436, rtol=1e-5, atol=1e-8)
+    assert np.isclose(PC.M, 7.414713702532491, rtol=1e-6)
+    assert np.isclose(PC.q, 1995.6098612984088, rtol=1e-6)
+
+
+def test_solve_wall_point_succeeds_when_intersection_exists(solver):
+    """
+    Regression test using a real point from a successful mesh row (see
+    test_solve_internal_point_matches_known_mesh_point for provenance
+    notes). Note this PB's x (10.08) is already past wall_params["x2"]
+    (9.39) -- the predictor line still happens to intersect the
+    extrapolated parabola here, it just isn't guaranteed to in general
+    (see the next test).
+    """
+    PB = Point(x=10.084175290859454, r=2.3015659141074742, theta=-0.3524386403089323,
+               M=9.437775698916417, q=2057.118908975743)
+
+    PC = solver.solve_wall_point(PB)
+
+    assert PC is not None
+    assert np.isfinite(PC.x) and np.isfinite(PC.r)
+
+
+def test_solve_wall_point_returns_none_past_wall_domain(solver, capsys):
+    """
+    Investigation finding: running the full 50x50 mesh from
+    axi-sym_MoC_solver.py's own example, solve_wall_point() first fails
+    (discriminant < 0, "no real intersection") at mesh row 18, where PB.x
+    = 11.27 -- about 20% beyond wall_params["x2"] = 9.39, the parabola's
+    defined z-extent. The intersection math itself checks out algebraically
+    (it is the standard line/parabola quadratic); the failure is a
+    consequence of the mesh outrunning the geometry it was given, not a
+    bug in the solve. This test locks in that observed behavior and checks
+    that the failure is now reported with a specific reason instead of a
+    bare "neg".
+    """
+    PB = Point(x=11.274183599427833, r=1.806742556073436, theta=-0.4059936956119819,
+               M=9.779187079764256, q=2064.278696921383)
+
+    PC = solver.solve_wall_point(PB)
+
+    assert PC is None
+    assert "outside the wall's defined domain" in capsys.readouterr().out

--- a/tests/test_os_solver.py
+++ b/tests/test_os_solver.py
@@ -1,6 +1,8 @@
-import pytest
 import numpy as np
+import pytest
+
 from src.oblique_shock_solver import ObliqueShockSolver
+
 
 # Fixture to initialize the solver instance
 @pytest.fixture

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from src.point import Point
 
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,0 +1,30 @@
+import numpy as np
+from src.point import Point
+
+
+def test_point_stores_fields_and_computes_mach_angle():
+    p = Point(x=1.0, r=2.0, theta=np.radians(10), M=2.0, q=0.9)
+
+    assert p.x == 1.0
+    assert p.r == 2.0
+    assert np.isclose(p.theta, np.radians(10))
+    assert p.M == 2.0
+    assert p.q == 0.9
+
+    # Mach angle: mu = asin(1/M)
+    expected_mu = np.arcsin(0.5)
+    assert np.isclose(p.mu, expected_mu, atol=1e-9)
+
+
+def test_point_mach_angle_at_sonic_is_ninety_degrees():
+    # At M=1 (sonic), mu = asin(1/1) = 90 degrees
+    p = Point(x=0, r=0, theta=0, M=1.0, q=1.0)
+    assert np.isclose(p.mu, np.radians(90), atol=1e-9)
+
+
+def test_point_repr_reports_degrees_not_radians():
+    # __repr__ converts theta/mu to degrees for display; regression guard
+    # against that conversion silently disappearing.
+    p = Point(x=1.0, r=2.0, theta=np.radians(30), M=2.0, q=0.9)
+    text = repr(p)
+    assert "theta=30.00" in text

--- a/tests/test_process_LE_points.py
+++ b/tests/test_process_LE_points.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from src.process_LE_points import extract_points_from_file
 
 

--- a/tests/test_process_LE_points.py
+++ b/tests/test_process_LE_points.py
@@ -1,0 +1,33 @@
+import numpy as np
+from src.process_LE_points import extract_points_from_file
+
+
+def test_extract_points_from_file(tmp_path):
+    """
+    extract_points_from_file() skips a fixed 6-line header, reads a point
+    count, then parses exactly that many whitespace-delimited x/y/z rows
+    (ignoring any extra columns or trailing rows beyond the stated count).
+    """
+    file_path = tmp_path / "leading_edge.nmb"
+    lines = [
+        "header line 1\n",
+        "header line 2\n",
+        "header line 3\n",
+        "header line 4\n",
+        "header line 5\n",
+        "header line 6\n",
+        "3\n",  # number of points
+        "1.0 2.0 3.0 extra_col\n",
+        "4.0 5.0 6.0\n",
+        "7.0 8.0 9.0\n",
+        "10.0 11.0 12.0\n",  # beyond the stated count; must be ignored
+    ]
+    file_path.write_text("".join(lines))
+
+    df = extract_points_from_file(str(file_path))
+
+    assert list(df.columns) == ["X", "Y", "Z"]
+    assert len(df) == 3
+    assert np.allclose(df["X"], [1.0, 4.0, 7.0])
+    assert np.allclose(df["Y"], [2.0, 5.0, 8.0])
+    assert np.allclose(df["Z"], [3.0, 6.0, 9.0])

--- a/tests/test_tm_solver.py
+++ b/tests/test_tm_solver.py
@@ -1,7 +1,8 @@
-import pytest
 import numpy as np
-import pandas as pd
+import pytest
+
 from src.taylor_maccoll_solver import TaylorMaccollSolver
+
 
 # Fixture to initialize the solver instance
 @pytest.fixture
@@ -37,7 +38,7 @@ def test_calculate_Mach_from_components(solver):
     # This is the inverse case of test_calculate_velocity_components()
     V_r = 0.845154249
     V_theta = 0.097590007
-    
+
     M = solver.calculate_Mach_from_components(V_r, V_theta)
 
     expected_M = 3.61986846
@@ -52,7 +53,7 @@ def test_taylor_maccoll_system(solver):
     Vr = 0.8
     dVr = 0.01
     result = solver.taylor_maccoll_system(theta, Vr, dVr)
-    
+
     expected_result = np.array([dVr, -1.622309628])
     assert np.allclose(result, expected_result, atol=1e-3)
 
@@ -69,15 +70,15 @@ def test_solve(solver):
 
     # Call the solve function
     theta_c, Vr, dVr = solver.solve(theta0, Vr0, dVr0)
-    
+
     # Assert V_theta ~ 0 (this is true at the cone angle)
     assert np.isclose(dVr, 0, atol=0.01), \
-        f"Solver did not return a value of 0 for V_theta."
+        "Solver did not return a value of 0 for V_theta."
 
     # Expected cone angle
     expected_theta_c = np.radians(26.5909011)  # Expected cone angle
     expected_Mc = 3.57846955    # Expected Mach at cone angle.
-    
+
     # Assert first and last Theta values
     assert np.isclose(theta_c, expected_theta_c, rtol=0.01), \
         f"Cone angle mismatch: {theta_c} != {expected_theta_c}"
@@ -88,7 +89,6 @@ def test_solve(solver):
 
 def test_tabulate_from_shock_to_cone(solver):
     theta_s = np.radians(30)
-    theta_w = np.radians(23.4132244)
     theta_c = np.radians( 26.5909011)
     Mc = 3.57846955
 

--- a/tests/test_velocity_altitude_map.py
+++ b/tests/test_velocity_altitude_map.py
@@ -1,9 +1,10 @@
 import numpy as np
+
 from src.velocity_altitude_map import (
-    calculate_pressure,
-    calculate_temperature,
     calculate_density,
     calculate_dynamic_pressure,
+    calculate_pressure,
+    calculate_temperature,
 )
 
 

--- a/tests/test_velocity_altitude_map.py
+++ b/tests/test_velocity_altitude_map.py
@@ -1,0 +1,55 @@
+import numpy as np
+from src.velocity_altitude_map import (
+    calculate_pressure,
+    calculate_temperature,
+    calculate_density,
+    calculate_dynamic_pressure,
+)
+
+
+def test_calculate_pressure_sea_level_matches_isa():
+    # Standard sea-level pressure is ~101325 Pa; this segmented model's own
+    # constants give a value within 1% of that ISA reference.
+    p = calculate_pressure(0)
+    assert np.isclose(p, 101325, rtol=0.01)
+
+
+def test_calculate_pressure_returns_pascals_not_kilopascals():
+    # calculate_pressure() explicitly converts kPa -> Pa; sea-level pressure
+    # in Pa is ~1e5, not ~1e2.
+    assert calculate_pressure(0) > 50_000
+
+
+def test_calculate_temperature_sea_level():
+    assert np.isclose(calculate_temperature(0), 15.04, atol=1e-6)
+
+
+def test_calculate_temperature_stratosphere_is_isothermal():
+    # Lower stratosphere (11 km - 25 km) is modeled as isothermal.
+    assert calculate_temperature(15000) == -56.46
+    assert calculate_temperature(20000) == -56.46
+
+
+def test_calculate_density_sea_level_matches_isa():
+    """
+    Regression test for a units bug: calculate_density() previously divided
+    Pascal-scale pressure by a gas constant scaled for kPa (0.2869),
+    producing a density ~1000x too high (~1225 kg/m^3 instead of the
+    correct ~1.225 kg/m^3 at sea level).
+    """
+    p = calculate_pressure(0)
+    t = calculate_temperature(0)
+    rho = calculate_density(p, t)
+    assert np.isclose(rho, 1.225, rtol=0.01)
+
+
+def test_calculate_dynamic_pressure_formula():
+    # q = 0.5 * gamma * p * M^2
+    q = calculate_dynamic_pressure(gamma=1.4, p=101325, M=1.0)
+    assert np.isclose(q, 0.5 * 1.4 * 101325, rtol=1e-9)
+
+
+def test_calculate_dynamic_pressure_scales_with_mach_squared():
+    q1 = calculate_dynamic_pressure(gamma=1.4, p=101325, M=1.0)
+    q2 = calculate_dynamic_pressure(gamma=1.4, p=101325, M=2.0)
+    assert np.isclose(q2, 4 * q1, rtol=1e-9)


### PR DESCRIPTION
## Summary

Follow-up to #19: closes part of the test-coverage gap, investigates a solver failure mode, adds linting, and type-hints the core reusable modules. Builds on top of #19's branch, so it should be reviewed/merged after that one.

## CI
New GitHub Actions job runs `pytest` (Python 3.11 and 3.12) and `ruff check .` on every push and PR against `main`.

## Test coverage (+17 tests, 7 -> 24)
Added regression tests for 5 previously-untested modules: `point.py`, `velocity_altitude_map.py`, `process_LE_points.py`, `metric_derivative_solver.py`, and `moc_solver_pc.py`. None of these require physics validation against Bowcutt's dissertation (still pending) -- they check self-consistent math, known reference values (e.g. standard ISA sea-level pressure/density), and agreement between independent implementations (hand-written vs. scipy interpolation) instead.

One of the new tests is a dedicated regression guard for the density units bug fixed in #19 -- it would have caught that bug directly.

## Investigation: why does `solve_wall_point()` sometimes return `None`?
Ran the actual MoC mesher with real parameters to root-cause this instead of guessing. Findings:
- The intersection algebra is correct (re-derived by hand: standard line/parabola quadratic).
- The mesh fully populates 18 rows before failing, and at the failing call the point is already ~20% past `wall_params["x2"]` -- the parabola is only a valid model of the body within `[x1, x2]`. This is a modeling-domain limit (the requested mesh size needs more wall geometry than was provided), not a bug.
- Added a specific failure message (previously just printed `'neg'`) and 3 regression tests using real captured values.

## Bug found via linting: `mu_c_prime` never updated in `solve_internal_point()`
While cleaning up a ruff unused-variable warning on `mu_c_new`, found that `solve_internal_point()`'s corrector loop computes a fresh `mu_c_new` (Equation 2.26, mu = asin(1/M)) every iteration but never feeds it back into `mu_c_prime`, even though `M_c_prime` **is** updated every iteration -- so `mu_c_prime` goes stale after the first iteration. Confirmed as a real bug (not intentional) by comparing against the sibling method `solve_wall_point()`, which already does this correctly. Fixed to match. Verified impact by re-running the full example mesh before/after: early rows are bit-for-bit unaffected (they converge before the staleness would matter), later rows shift in the 5th-6th significant digit.

## Linting
Added `ruff` (pyflakes + pycodestyle + import sorting, 120-char line length) via `pyproject.toml` and `requirements-dev.txt`. Fixed everything it found: unsorted imports, unused imports/variables (including one case -- `lower_surface_pressure_solver.py`'s `cell_T_T0`/`cell_rho_rho0` -- that looked like an unfinished feature rather than dead code, so stored them on `self` to match the already-existing `self.cell_mach` pattern instead of deleting), trailing whitespace, and long lines.

## Type hints
Added parameter/return type hints to the six reusable library classes (`ObliqueShockSolver`, `TaylorMaccollSolver`, `IsentropicRelationsSolver`, `ConicalFlowAnalyzer`, `Point`, `AxisymMoC`). Deliberately left the ~7 standalone demo scripts untyped, since hints add little value to code nothing else imports. Not run through mypy/pyright -- these are unverified by a type checker, just consistent with existing docstrings and call sites.

## Testing
24 of 24 tests pass. `ruff check .` passes clean.
