### PR TITLE
Fix CI: pytest job fails on Python 3.11 (numpy 2.5.2 needs 3.12+)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: pip
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pytest
 
 Any bug fix or new solver logic should keep existing tests passing and add new tests alongside it. Test coverage spans the isentropic, oblique shock, Taylor-Maccoll, and MoC point solvers, plus `point.py`, `process_LE_points.py`, `metric_derivative_solver.py`, and `velocity_altitude_map.py`. The streamline integrator and surface pressure solver still have no automated tests.
 
-A GitHub Actions workflow (`.github/workflows/tests.yml`) runs the full suite on every push and pull request against `main`, on Python 3.11 and 3.12.
+A GitHub Actions workflow (`.github/workflows/tests.yml`) runs the full suite on every push and pull request against `main`, on Python 3.12 (the version `requirements.txt` is pinned against).
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,6 @@
 
 [pytest]
 
-pythonpath = src
+pythonpath = . src
 
 testpaths = tests


### PR DESCRIPTION
The 3.11/3.12 test matrix broke main right after PR #20 merged -- numpy==2.5.2 has no Python 3.11 wheel, so pip install failed before any test ran. I added that matrix without ever verifying the pinned deps actually install on 3.11. Narrowed CI to Python 3.12 only, matching what's actually been verified and what the README already claimed. Also fixed a README line that (incorrectly) said CI covered both versions.